### PR TITLE
Test README for OctoPunk link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,81 @@
-# Litee-gh-testing
+# OctoPunk Link Handler Test README
 
-this is a test repository for developing `litee-gh.nvim`
+This README contains real GitHub links to test in-app navigation for all supported link types.
+
+## User Links
+
+- [@torvalds](https://github.com/torvalds) - Linus Torvalds
+- [@gvanrossum](https://github.com/gvanrossum) - Guido van Rossum
+- [@ldelossa](https://github.com/ldelossa) - Louis DeLosSantos
+
+## Repository Links
+
+- [neovim/neovim](https://github.com/neovim/neovim) - Vim-fork focused on extensibility
+- [facebook/react](https://github.com/facebook/react) - React JS library
+- [cilium/cilium](https://github.com/cilium/cilium) - eBPF-based networking
+
+## Issue Links
+
+- [neovim/neovim#1](https://github.com/neovim/neovim/issues/1) - First issue in Neovim
+- [facebook/react#28931](https://github.com/facebook/react/issues/28931) - Recent React issue
+- [golang/go#1](https://github.com/golang/go/issues/1) - First issue in Go
+
+## Pull Request Links
+
+- [neovim/neovim#31575](https://github.com/neovim/neovim/pull/31575) - Recent Neovim PR
+- [facebook/react#31677](https://github.com/facebook/react/pull/31677) - Recent React PR
+- [cilium/cilium#36886](https://github.com/cilium/cilium/pull/36886) - Recent Cilium PR
+
+## Commit Links
+
+- [neovim/neovim@b17d966](https://github.com/neovim/neovim/commit/b17d966) - Short SHA (the original test case!)
+- [neovim/neovim@b17d9666ec2e8267c3dc2a9a8bd90e2cd90b1ada](https://github.com/neovim/neovim/commit/b17d9666ec2e8267c3dc2a9a8bd90e2cd90b1ada) - Full SHA
+- [facebook/react@06092a0](https://github.com/facebook/react/commit/06092a0) - React commit
+- [golang/go@2580d0e](https://github.com/golang/go/commit/2580d0e) - Go commit
+
+## File Links
+
+- [neovim/neovim - init.lua](https://github.com/neovim/neovim/blob/master/src/nvim/lua/vim.lua) - Neovim Lua file
+- [facebook/react - package.json](https://github.com/facebook/react/blob/main/package.json) - React package.json
+- [cilium/cilium - README.rst](https://github.com/cilium/cilium/blob/main/README.rst) - Cilium README
+
+## File Links with Line Numbers
+
+- [neovim source L10-L20](https://github.com/neovim/neovim/blob/master/src/nvim/main.c#L10-L20) - Lines 10-20 of main.c
+- [react source L1](https://github.com/facebook/react/blob/main/packages/react/index.js#L1) - First line of react index
+- [go source L50](https://github.com/golang/go/blob/master/src/runtime/proc.go#L50) - Line 50 of proc.go
+
+## Tree/Branch Links
+
+- [neovim master branch](https://github.com/neovim/neovim/tree/master) - Neovim master
+- [react main branch](https://github.com/facebook/react/tree/main) - React main
+- [cilium v1.16 branch](https://github.com/cilium/cilium/tree/v1.16) - Cilium v1.16 branch
+- [go release-branch.go1.23](https://github.com/golang/go/tree/release-branch.go1.23) - Go 1.23 release branch
+
+## Release/Tag Links
+
+- [neovim v0.10.0](https://github.com/neovim/neovim/releases/tag/v0.10.0) - Neovim 0.10.0 release
+- [react v18.3.1](https://github.com/facebook/react/releases/tag/v18.3.1) - React 18.3.1 release
+- [cilium v1.16.0](https://github.com/cilium/cilium/releases/tag/v1.16.0) - Cilium 1.16.0 release
+- [go go1.23.0](https://github.com/golang/go/releases/tag/go1.23.0) - Go 1.23.0 release
+
+## Action Run Links
+
+- [neovim CI run](https://github.com/neovim/neovim/actions/runs/12369067955) - Recent Neovim CI
+- [react CI run](https://github.com/facebook/react/actions/runs/12381159498) - Recent React CI
+- [cilium CI run](https://github.com/cilium/cilium/actions/runs/12380925498) - Recent Cilium CI
+
+## External Links (should open in browser)
+
+- [Google](https://google.com) - External link
+- [Neovim Docs](https://neovim.io/doc/) - External docs
+- [eBPF.io](https://ebpf.io) - External eBPF site
+
+## Links That Should NOT Be Intercepted
+
+These link types don't have corresponding views in OctoPunk and should open in browser:
+
+- [neovim wiki](https://github.com/neovim/neovim/wiki) - Wiki (no view)
+- [react discussions](https://github.com/facebook/react/discussions) - Discussions (no view)
+- [cilium blame](https://github.com/cilium/cilium/blame/main/README.rst) - Blame (no view)
+- [go compare](https://github.com/golang/go/compare/go1.22.0...go1.23.0) - Compare (no view yet)


### PR DESCRIPTION
## Summary
Comprehensive test README with real GitHub links to test in-app navigation for all supported link types in OctoPunk.

## Link Types Covered
- **User links**: @torvalds, @gvanrossum, @ldelossa
- **Repository links**: neovim/neovim, facebook/react, cilium/cilium
- **Issue links**: First issues in neovim, react, go
- **PR links**: Recent PRs in neovim, react, cilium
- **Commit links**: Short SHA (b17d966) and full SHA formats
- **File links**: With and without line numbers
- **Tree/branch links**: master, main, version tags
- **Release/tag links**: Various releases
- **Action run links**: Recent CI runs
- **External links**: Should open in browser
- **Non-intercepted links**: wiki, discussions, blame, compare (no views in OctoPunk)

## Testing
1. Merge this PR
2. Open ldelossa/litee-gh-testing in OctoPunk
3. Click each link type and verify it navigates correctly within the app
4. Verify external links open in browser